### PR TITLE
Added rootDir option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,9 @@
 #   The desired installation directory (Will not be created, it needs to exist)
 #   $installDir
 #
+#   Define root_dir (for archive). Default to '/'
+#   $rootDir
+#
 #   The path to the directory where you wish your configuration to be stored (Please note that this diirectory ill automatically be created if it does not exist)
 #   $configDir - see http://zookeeper.apache.org/doc/r3.3.3/zookeeperAdmin.html#sc_zkMulitServerSetup
 #
@@ -99,6 +102,7 @@ class zookeeper (
   $manage_user            = true,
   $tmpDir                 = '/tmp',
   $installDir             = '/opt/zookeeper',
+  $rootDir                = '/',
   $jvmFlags               = '-Dzookeeper.log.threshold=INFO -Xmx1024m',
 #  Zookeeper configuration parameters
   $dataLogDir             = '/var/log/zookeeper',
@@ -151,6 +155,7 @@ class zookeeper (
     $digest_string,
     $digest_type,
     $installDir,
+    $rootDir,
     $configDir,
     $dataDir,
     $jvmFlags,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,8 @@ class zookeeper::install (
   $user               = $zookeeper::user,
   $manage_user        = $zookeeper::manage_user,
   $tmpDir             = $zookeeper::tmpDir,
-  $installDir         = $zookeeper::installDir
+  $installDir         = $zookeeper::installDir,
+  $rootDir            = $zookeeper::rootDir
 ) inherits zookeeper {
 
 
@@ -29,6 +30,7 @@ class zookeeper::install (
     $extension,
     $user,
     $installDir,
+    $rootDir,
     $tmpDir
   )
 
@@ -65,6 +67,7 @@ class zookeeper::install (
       url              => $url,
       src_target       => $tmpDir,
       target           => $installDir,
+      root_dir         => $rootDir,
       strip_components => 1,
       follow_redirects => $follow_redirects,
       extension        => $extension,


### PR DESCRIPTION
.tar.gz is continuously unzipped when puppet runs: the archive root_dir variable has undef by default. Then, extract_dir will be always $installDir/zookeeper and 'creates' will always fail, in this manner file will be always unzipped. Addind the rootDir and setting it to '/' will force extract_dir to be $installDir/$rootDir. rootDir should work with the default "", but for some reason in my puppet version it doesn't, so '/' will fix it anyway.